### PR TITLE
Return loss, but not predictions and target during training steps to save GPU memory

### DIFF
--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.project_slug}}/models/mnist_module.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.project_slug}}/models/mnist_module.py
@@ -69,7 +69,7 @@ class MNISTLitModule(LightningModule):
         # we can return here dict with any tensors
         # and then read it in some callback or in `training_epoch_end()`` below
         # remember to always return loss from `training_step()` or else backpropagation will fail!
-        return {"loss": loss, "preds": preds, "targets": targets}
+        return {"loss": loss}
 
     def training_epoch_end(self, outputs: List[Any]):
         # `outputs` is a list of dicts returned from `training_step()`


### PR DESCRIPTION
Note that at each step, besides the loss, predictions and target are generated and put in the return dictionary. This dictionary could be used at training_epoch_end , but the values are never required. Still they are kept in GPU memory, which is then growing during training up to a point where it can exceed available GPU memory (as happened when we were using large images in the validation set). The proposed solution is to return only the loss by default, as the error was hard to find when it occurs, 

More notes on our debugging process:

https://medium.com/@caroline.arnold_63207/reclaim-your-gpu-memory-5fb80a980a09